### PR TITLE
Fixing python install

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -64,7 +64,7 @@ if include_libs:
     rpath = [os.path.relpath(path, CURRENT_DIR) for path in LIBS]
     setup_kwargs = {
         "include_package_data": True,
-        "data_files": [('decord', ['libdecord.dylib'])]
+        "data_files": [('decord', rpath)]
     }
 
 setup(


### PR DESCRIPTION
I am not sure why this was changed here (https://github.com/georgia-tech-db/eva-decord/commit/67ba7a1ecad8601546da3428f7382b1dcc6989c0) but this PR reverts so that `setup.py` can find the compiled `libdecord.dylib` file.